### PR TITLE
[Setting] CI 설정

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,9 @@ jobs:
         with:
           java-version: '11'
           distribution: 'temurin'
+          
+      - name: Validate Gradle wrapper
+        uses: gradle/wrapper-validation-action@ccb4328a959376b642e027874838f60f8e596de3
 
       - name: Grant execute permission for gradlew
         run: chmod +x ./notification/gradlew

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,5 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x ./notification/gradlew
 
-      - name: Build with Gradle
-        uses: gradle/gradle-build-action@749f47bda3e44aa060e82d7b3ef7e40d953bd629
-        with:
-          arguments: build
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,9 +31,6 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x ./notification/gradlew
 
-      - name: spotless check
-        run: ./notification/gradlew spotlessCheck
-
       - name: Build with Gradle
         uses: gradle/gradle-build-action@749f47bda3e44aa060e82d7b3ef7e40d953bd629
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,3 +36,6 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
+        
+      - name: Execute Gradle build
+        run: ./notification/gradlew build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,8 +34,8 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x ./notification/gradlew
 
-      - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2
-        
-      - name: Execute Gradle build
-        run: ./notification/gradlew build
+      - name: Build with Gradle
+        uses: gradle/gradle-build-action@749f47bda3e44aa060e82d7b3ef7e40d953bd629
+        with:
+          arguments: build
+          build-root-directory: ./notification

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -29,7 +29,7 @@ jobs:
           distribution: 'temurin'
 
       - name: Grant execute permission for gradlew
-        run: chmod +x ./gradlew
+        run: chmod +x ./notification/gradlew
 
       - name: spotless check
         run: ./gradlew spotlessCheck

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,0 +1,40 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+# This workflow will build a Java project with Gradle and cache/restore any dependencies to improve the workflow execution time
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-gradle
+
+name: Java CI with Gradle
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      
+      - name: Set Up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x ./gradlew
+
+      - name: spotless check
+        run: ./gradlew spotlessCheck
+
+      - name: Build with Gradle
+        uses: gradle/gradle-build-action@749f47bda3e44aa060e82d7b3ef7e40d953bd629
+        with:
+          arguments: build

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -32,7 +32,7 @@ jobs:
         run: chmod +x ./notification/gradlew
 
       - name: spotless check
-        run: ./gradlew spotlessCheck
+        run: ./notification/gradlew spotlessCheck
 
       - name: Build with Gradle
         uses: gradle/gradle-build-action@749f47bda3e44aa060e82d7b3ef7e40d953bd629


### PR DESCRIPTION
## 🟨 이슈
#2 

```
 - name: Build with Gradle
        uses: gradle/gradle-build-action@749f47bda3e44aa060e82d7b3ef7e40d953bd629
        with:
          arguments: build
          build-root-directory: ./notification
```
build-root-directory를 바꿔줘야 한다.
gradle 관련 파일이 ./notification에 있기 때문이다.
그렇지 않으면 아래와 같은 에러가 뜬다.
```
FAILURE: Build failed with an exception.

* What went wrong:
Directory '/home/runner/work/notification-practice/notification-practice' does not contain a Gradle build.

A Gradle build should contain a 'settings.gradle' or 'settings.gradle.kts' file in its root directory. It may also contain a 'build.gradle' or 'build.gradle.kts' file.
```